### PR TITLE
Added configurable esprima options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ Program
 
 ### `var tree = program( sourceCode, options )`
 - **sourceCode** (String) - The source code to edit.
-- **options** (Object) _optional_ - [escodegen](https://github.com/Constellation/escodegen) option object
+- **escodegenOptions** (Object) _optional_ - [escodegen](https://github.com/Constellation/escodegen) option object
+- **esprimaOptions** (Object) _optional_ - object[esprima](http://esprima.org/doc) option 
 
 Returns an AST tree you can then query as explained below:
 

--- a/lib/tree.js
+++ b/lib/tree.js
@@ -9,7 +9,7 @@ var CallExpression = require('./nodes/CallExpression');
 var AssignmentExpression = require('./nodes/AssignmentExpression');
 var Body = require('./nodes/Body');
 
-var esprimaOptions = {
+var esprimaOptionDefaults = {
   comment: true,
   range: true,
   loc: false,
@@ -17,7 +17,7 @@ var esprimaOptions = {
   raw: false
 };
 
-var escodegenOptions = {
+var escodegenOptionDefaults = {
   comment: true,
   format: {
     indent: {
@@ -26,11 +26,12 @@ var escodegenOptions = {
   }
 };
 
-function Tree(source, options) {
-  this.tree = esprima.parse(source.toString(), esprimaOptions);
+function Tree(source, escodegenOptions, esprimaOptions) {
+  this.esprimaOptionDefaults = _.merge({}, esprimaOptionDefaults, esprimaOptions);
+  this.tree = esprima.parse(source.toString(), this.esprimaOptionDefaults);
   this.tree = escodegen.attachComments(this.tree, this.tree.comments, this.tree.tokens);
   this.body = new Body(this.tree.body);
-  this.escodegenOptions = _.merge({}, escodegenOptions, options);
+  this.escodegenOptions = _.merge({}, escodegenOptionDefaults, escodegenOptions);
 }
 
 /**
@@ -97,6 +98,6 @@ Tree.prototype.assignment = function (assignedTo) {
   return new AssignmentExpression(nodes);
 };
 
-module.exports = function (source, options) {
-  return new Tree(source, options);
+module.exports = function (source, escodegenOptions, esprimaOptions) {
+  return new Tree(source, escodegenOptions, esprimaOptions);
 };

--- a/test/tree.js
+++ b/test/tree.js
@@ -27,14 +27,14 @@ describe('Tree', function () {
     });
   });
 
-  describe('created with default options', function () {
+  describe('created with default escodegen options', function () {
     it('return the generated source code', function () {
       var tree = program('(function () {\n\tconsole.log("foo");\n\tconsole.log("bar");\n})();');
       assert.equal(tree.toString().charAt(15), ' ');
     });
   });
 
-  describe('created with tab formatting option', function () {
+  describe('created with tab formatting escodegen option', function () {
     it('return the generated source code', function () {
       var tree = program('(function () {\n  console.log("foo");\n  console.log("bar");\n})();', {
         format: {
@@ -47,4 +47,29 @@ describe('Tree', function () {
     });
   });
 
+  describe('created with default esprima options', function () {
+    it('parses the source code as a script', function () {
+      assert.doesNotThrow(function () {
+        program('var a = 1;');
+      }, Error);
+    });
+    it('does not parse the source code as a module', function () {
+      assert.throws(function() {
+        program('var a = 1;\nexport default a;');
+      }, Error);
+    });
+  });
+
+  describe('created with es2015 module esprima options', function () {
+    it('does not parse the module source code when the sourceType configuration is missing', function () {
+      assert.throws(function() {
+        program('var a = 1;\nexport default a;');
+      }, Error);
+    });
+    it('parses the source code as a module when the sourceType configuration is present', function () {
+      assert.doesNotThrow(function () {
+        program('var a = 1;\nexport default a;', {}, { sourceType: 'module'});
+      }, Error);
+    });
+  });
 });


### PR DESCRIPTION
Added an additional configuration option to the Tree object so that esprima options can be passed in by the caller.  This enables configuration changes such as `{ sourceType: 'module' }` which allows es2015 source code to be parsed.
